### PR TITLE
add support for varargs help message

### DIFF
--- a/argh/assembling.py
+++ b/argh/assembling.py
@@ -114,7 +114,13 @@ def _get_args_from_signature(function):
 
     if spec.varargs:
         # *args
-        yield dict(option_strings=[spec.varargs], nargs='*')
+        akwargs = dict(nargs='*')
+        name = spec.varargs
+
+        if name in annotations:
+            akwargs.update(help=annotations.get(name))
+
+        yield dict(option_strings=[name], **akwargs)
 
 
 def _guess(kwargs):


### PR DESCRIPTION
adds help from varargs annotations

This is a copy of upstream PR https://github.com/neithere/argh/pull/137

This is arguably a bug fix, since the user's expectation would be that varargs would not be treated differently from normal args in this context.

It does technically weakly break backwards compatability - If users are setting the annotation but it's currently not taking effect, this will cause the annotation to now be displayed. This is a difference but a good one, so this is fine.