### PR TITLE
Use type annotations for arg casting, add arg doc decorator

### DIFF
--- a/yaargh/assembling.py
+++ b/yaargh/assembling.py
@@ -97,7 +97,7 @@ def _get_args_from_signature(function):
                 akwargs.update(help=val)
             elif val in PARSED_TYPEHINTS:
                 # typed arg:     func(a : int) -> add_argument("a", type=int)
-                akwargs.update(type=val)
+                akwargs.update(type=PARSED_TYPEHINTS[val])
 
         if name in defaults or name in kwonly:
             if name in defaults:

--- a/yaargh/constants.py
+++ b/yaargh/constants.py
@@ -14,6 +14,7 @@ __all__ = (
     'ATTR_NAME', 'ATTR_ALIASES', 'ATTR_ARGS', 'ATTR_WRAPPED_EXCEPTIONS',
     'ATTR_WRAPPED_EXCEPTIONS_PROCESSOR', 'ATTR_EXPECTS_NAMESPACE_OBJECT',
     'PARSER_FORMATTER', 'DEFAULT_ARGUMENT_TEMPLATE', 'DEST_FUNCTION',
+    'PARSED_TYPEHINTS', 'ARG_DOC_DICT'
 )
 
 
@@ -39,12 +40,18 @@ ATTR_WRAPPED_EXCEPTIONS_PROCESSOR = 'argh_wrap_errors_processor'
 #: forcing argparse.Namespace object instead of signature introspection
 ATTR_EXPECTS_NAMESPACE_OBJECT = 'argh_expects_namespace_object'
 
+#: a dict {argname: infostr} to be used for adding --help info
+ARG_DOC_DICT = 'argh_doc_dict'
+
 #
 # Dest names in parser defaults
 #
 
 #: dest name for a function mapped to given endpoint (goes to Namespace obj)
 DEST_FUNCTION = 'function'
+
+#: list of type annotations to use for marking argument types
+PARSED_TYPEHINTS = [int, float, str, bool]
 
 #
 # Other library-wide stuff

--- a/yaargh/constants.py
+++ b/yaargh/constants.py
@@ -9,6 +9,7 @@
 #  Software Foundation. See the file README.rst for copying conditions.
 #
 import argparse
+from .utils import str_to_bool
 
 __all__ = (
     'ATTR_NAME', 'ATTR_ALIASES', 'ATTR_ARGS', 'ATTR_WRAPPED_EXCEPTIONS',
@@ -50,8 +51,14 @@ ARG_DOC_DICT = 'argh_doc_dict'
 #: dest name for a function mapped to given endpoint (goes to Namespace obj)
 DEST_FUNCTION = 'function'
 
-#: list of type annotations to use for marking argument types
-PARSED_TYPEHINTS = [int, float, str, bool]
+#: type annotations to use for marking argument types and associated converters
+
+PARSED_TYPEHINTS = {
+    int: int,
+    float: float,
+    str: str,
+    bool: str_to_bool
+}
 
 #
 # Other library-wide stuff

--- a/yaargh/decorators.py
+++ b/yaargh/decorators.py
@@ -13,12 +13,12 @@ Command decorators
 ~~~~~~~~~~~~~~~~~~
 """
 from .constants import (ATTR_ALIASES, ATTR_ARGS, ATTR_NAME,
-                        ATTR_WRAPPED_EXCEPTIONS,
+                        ATTR_WRAPPED_EXCEPTIONS, ARG_DOC_DICT,
                         ATTR_WRAPPED_EXCEPTIONS_PROCESSOR,
                         ATTR_EXPECTS_NAMESPACE_OBJECT)
 
 
-__all__ = ['aliases', 'named', 'arg', 'wrap_errors', 'expects_obj']
+__all__ = ['aliases', 'named', 'arg', 'argdoc', 'wrap_errors', 'expects_obj']
 
 
 def named(new_name):
@@ -69,6 +69,23 @@ def aliases(*names):
     """
     def wrapper(func):
         setattr(func, ATTR_ALIASES, names)
+        return func
+    return wrapper
+
+
+def argdoc(helpdict):
+    """
+    Adds argument help to a function.
+
+    Usage::
+
+        @argdoc({'x': 'a positive integer',
+                 'y': 'any number you want')
+        def func(x, y):
+            return sqrt(x) + y
+    """
+    def wrapper(func):
+        setattr(func, ARG_DOC_DICT, helpdict)
         return func
     return wrapper
 

--- a/yaargh/utils.py
+++ b/yaargh/utils.py
@@ -14,7 +14,7 @@ Utilities
 """
 import argparse
 import inspect
-
+import distutils.util
 from . import compat
 
 
@@ -55,3 +55,8 @@ def get_arg_spec(function):
     if inspect.ismethod(function):
         spec = spec._replace(args=spec.args[1:])
     return spec
+
+
+def str_to_bool(s):
+    return bool(distutils.util.strtobool(s))
+str_to_bool.__name__ = 'bool'   # make argparse errors informative


### PR DESCRIPTION
This adds partial integration with 3.5+ type annotations as discussed in [the argh issues.](https://github.com/neithere/argh/issues/107) Specifically, for each of the types str, int, float, bool, adding an annotation of that type to an argument will do what you think and ensure the argument is cast to that type before being passed to the function. (Default arguments and the `@arg` decorator can both override this.) Boolean arguments are parsed with the stdlib function `distutils.util.strtobool`, while the other types are just parsed with their type constructor.

Because this cannot be used simultaneously with the currently supported use of annotations to add argument help, an `@argdoc` decorator is also added. Here's an example usecase for both new features: (Note that this is entirely backwards compatible, so both old and new style work just fine in this branch.)

```
# current style
@yaargh.arg('x', type=float)
@yaargh.arg('y', type=int)
def func(x, y: 'info about y', z):
    pass


# new style
@yaargh.argdoc({
    'y': 'info about y',
})
def func(x: float, y: int, z):
    pass
``` 

There may well be nicer way to do this with argh in its current form - if so I'd love to hear them. 

Apologies if this is unwanted, it just seemed like a convenient feature to me. I'm also happy to modify it if it'd help. A couple of things I was uncertain about:

- Should `@argdoc` throw an error if the dict passed contain arguments the function doesn't take? It seems like an easy mistake to make, and it will perhaps be confusing for it to pass silently.
- Should there be a way to support arbitrary type annotations? Maybe annotating with any old callable should be fine and have the effect of passing the argument through the callable. I think this quickly gets weird, and is probably best left for an `@arg` decorator.